### PR TITLE
Use cloginrc in nas script when using hostname on command line

### DIFF
--- a/lib/Net/Appliance/Session/Scripting.pm
+++ b/lib/Net/Appliance/Session/Scripting.pm
@@ -199,6 +199,7 @@ sub run {
         }
     }
     else {
+        get_creds_from_cloginrc();
         do_session(%options);
     }
 


### PR DESCRIPTION
When using a hostname or IP on the command line, the cloginrc file was not consulted.