### PR TITLE
fix syntax error with $VERSION

### DIFF
--- a/lib/Net/Appliance/Session/Scripting.pm
+++ b/lib/Net/Appliance/Session/Scripting.pm
@@ -19,7 +19,7 @@ use Text::Glob qw(match_glob);
 use Net::Appliance::Session;
 
 my $banner = colored ['blue'],
-  "Net Appliance Session scripting - v$VERSION - © 2012-2017 by Oliver Gorwits\n";
+  sprintf "Net Appliance Session scripting - v%s - © 2012-2017 by Oliver Gorwits\n", $Net::Appliance::Session::Scripting::VERSION;
 
 my %options = (cloginrc_opts => {});
 my $exit_status = 0;
@@ -101,7 +101,7 @@ sub commandline {
     bailout() if exists $options{help};
 
     if (exists $options{version}) {
-        print "nas version $VERSION\n";
+        printf "nas version %s\n", $Net::Appliance::Session::Scripting::VERSION;
         exit(0);
     }
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Net-Appliance-Session.
We thought you might be interested in it too.

    Description: fix syntax error with $VERSION
     Variable "$VERSION" is not imported at /usr/share/perl5/Net/Appliance/Session/Scripting.pm line 22.
     Variable "$VERSION" is not imported at /usr/share/perl5/Net/Appliance/Session/Scripting.pm line 105.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-01-02
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libnet-appliance-session-perl.git/plain/debian/patches/VERSION.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
